### PR TITLE
Update stretch.js to correct window width

### DIFF
--- a/assets/js/src/shared/components/ui/stretch.js
+++ b/assets/js/src/shared/components/ui/stretch.js
@@ -49,7 +49,7 @@ Stretch = Components.create( {
         var width = rect.width;
         var left = rect.left;
 
-        this.el.style.width = window.innerWidth + 'px';
+        this.el.style.width = document.body.clientWidth + 'px';
         this.el.style.marginLeft = - left + 'px';
 
         if ( this.options.retainContentWidth ) {


### PR DESCRIPTION
Replaces `window.innerWidth` with `document.body.clientWidth` to calc the width of window correctly, without scrollbar.